### PR TITLE
Add Init Containers

### DIFF
--- a/charts/keycloak-config-cli/Chart.yaml
+++ b/charts/keycloak-config-cli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 1.2.3
+version: 1.3.0
 # renovate: image=adorsys/keycloak-config-cli
 appVersion: 5.0.0
 maintainers:

--- a/charts/keycloak-config-cli/templates/job.yaml
+++ b/charts/keycloak-config-cli/templates/job.yaml
@@ -28,6 +28,10 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       containers:
         - name: keycloak-config-cli
           image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag $ }}"

--- a/charts/keycloak-config-cli/values.yaml
+++ b/charts/keycloak-config-cli/values.yaml
@@ -37,6 +37,15 @@ env:
   KEYCLOAK_USER: admin
   IMPORT_FILES_LOCATIONS: /config/
 
+# Add additional init containers, e.g: wait for keycloak to be ready
+initContainers: []
+  # - name: keycloak-health
+  #   image: curlimages/curl
+  #   command:
+  #     - sh
+  #     - -c
+  #     - until curl -fsS {{ .Values.env.KEYCLOAK_URL }}/health/ready; do sleep 5; done
+
 secrets: {}
 #  KEYCLOAK_PASSWORD:
 


### PR DESCRIPTION
This adds the ability to add optional Init Containers to the job.
For example, check that keycloak is in a healthy state:
```yaml
initContainers:
  - name: keycloak-health
    image: curlimages/curl
    command:
      - sh
      - -c
      - until curl -fsS {{ .Values.env.KEYCLOAK_URL }}/health/ready; do sleep 5; done
```