### PR TITLE
Add missing namespaces

### DIFF
--- a/charts/amazon-eks-pod-identity-webhook/templates/role.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/role.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
 rules:
@@ -20,6 +21,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
 roleRef:

--- a/charts/amazon-eks-pod-identity-webhook/templates/service.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
   {{- with .Values.serviceAnnotations }}

--- a/charts/amazon-eks-pod-identity-webhook/templates/serviceaccount.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "amazon-eks-pod-identity-webhook.serviceAccountName" . }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/amazon-eks-pod-identity-webhook/templates/servicemonitor.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Release.Name }}
+  namespace: {{ include "amazon-eks-pod-identity-webhook.namespace" . }}
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
   {{- with .Values.metrics.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
Some namespaced resources created by `amazon-eks-pod-identity-webhook` are missing `.metadata.namespace` fields.
This PR fixes it.