### PR TITLE
feat(amazon-eks-pod-identity-webhook): allow a set of configuration fields to be templated

### DIFF
--- a/charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: amazon-eks-pod-identity-webhook
 description: A Kubernetes webhook for pods that need AWS IAM access
-version: 2.4.3
+version: 2.5.0
 type: application
 # renovate: image=amazon/amazon-eks-pod-identity-webhook
 appVersion: "v0.6.4"

--- a/charts/amazon-eks-pod-identity-webhook/README.md
+++ b/charts/amazon-eks-pod-identity-webhook/README.md
@@ -1,6 +1,6 @@
 # amazon-eks-pod-identity-webhook
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.7](https://img.shields.io/badge/AppVersion-v0.5.7-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
 
 A Kubernetes webhook for pods that need AWS IAM access
 

--- a/charts/amazon-eks-pod-identity-webhook/README.md
+++ b/charts/amazon-eks-pod-identity-webhook/README.md
@@ -1,6 +1,6 @@
 # amazon-eks-pod-identity-webhook
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.4](https://img.shields.io/badge/AppVersion-v0.6.4-informational?style=flat-square)
 
 A Kubernetes webhook for pods that need AWS IAM access
 

--- a/charts/amazon-eks-pod-identity-webhook/templates/configmap.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
 data:
-  config: {{ .Values.config.podIdentityWebhookMap.data | toJson | quote }}
+  config: {{ .Values.config.podIdentityWebhookMap.data | toJson | tpl . | quote }}
 {{- end }}

--- a/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - --metrics-port={{ .Values.config.ports.metrics }}
             - --port={{ .Values.config.ports.webhook }}
             - --service-name={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
-            - --sts-regional-endpoint={{ tpl .Values.config.stsRegionalEndpoint . }}
+            - --sts-regional-endpoint={{ tpl (print .Values.config.stsRegionalEndpoint) . }}
             - --token-audience={{ tpl .Values.config.tokenAudience . }}
             - --token-expiration={{ .Values.config.tokenExpiration }}
             - --token-mount-path={{ .Values.config.tokenMountPath }}

--- a/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
@@ -40,16 +40,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /webhook
-            - --annotation-prefix={{ .Values.config.annotationPrefix }}
-            - --aws-default-region={{ .Values.config.defaultAwsRegion }}
+            - --annotation-prefix={{ tpl .Values.config.annotationPrefix . }}
+            - --aws-default-region={{ tpl .Values.config.defaultAwsRegion . }}
             - --in-cluster=false
             - --logtostderr
             - --namespace=$(POD_NAMESPACE)
             - --metrics-port={{ .Values.config.ports.metrics }}
             - --port={{ .Values.config.ports.webhook }}
             - --service-name={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
-            - --sts-regional-endpoint={{ .Values.config.stsRegionalEndpoint }}
-            - --token-audience={{ .Values.config.tokenAudience }}
+            - --sts-regional-endpoint={{ tpl .Values.config.stsRegionalEndpoint . }}
+            - --token-audience={{ tpl .Values.config.tokenAudience . }}
             - --token-expiration={{ .Values.config.tokenExpiration }}
             - --token-mount-path={{ .Values.config.tokenMountPath }}
             - --tls-cert=/etc/webhook/certs/tls.crt

--- a/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - --watch-config-map
             {{- end }}
             {{- if .Values.config.extraArgs }}
-            {{- toYaml .Values.config.extraArgs | nindent 12 }}
+            {{- tpl (toYaml .Values.config.extraArgs) . | nindent 12 }}
             {{- end }}
           ports:
             - name: https


### PR DESCRIPTION
This PR introduces the usage of the helm tpl function for a set of deployment fields, making it possible to (in my case) use global values to configure individual audiences, prefixes and endpoints per cluster