### PR TITLE
Added the scheme HTTPS

### DIFF
--- a/charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: amazon-eks-pod-identity-webhook
 description: A Kubernetes webhook for pods that need AWS IAM access
-version: 2.3.0
+version: 2.3.1
 type: application
 # renovate: image=amazon/amazon-eks-pod-identity-webhook
 appVersion: "v0.6.1"

--- a/charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -139,12 +139,14 @@ readinessProbe:
     # -- This is the readiness check endpoint
     path: /healthz
     port: https
+    scheme: HTTPS
 
 livenessProbe:
   httpGet:
     # -- This is the liveness check endpoint
     path: /healthz
     port: https
+    scheme: HTTPS
 
 # -- Annotations for amazon-eks-pod-identity-webhook deployment
 annotations: {}


### PR DESCRIPTION
New versions of the https://github.com/aws/amazon-eks-pod-identity-webhook use HTTPS protocol for `/healthz` endpoint