### PR TITLE
fix(amazon-eks-pod-identity-webhook): use correct default values for webhook.objectSelector.(matchExpressions|matchLabels)

### DIFF
--- a/charts/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: amazon-eks-pod-identity-webhook
 description: A Kubernetes webhook for pods that need AWS IAM access
-version: 2.4.0
+version: 2.4.1
 type: application
 # renovate: image=amazon/amazon-eks-pod-identity-webhook
 appVersion: "v0.6.1"

--- a/charts/amazon-eks-pod-identity-webhook/values.yaml
+++ b/charts/amazon-eks-pod-identity-webhook/values.yaml
@@ -84,13 +84,13 @@ mutatingWebhook:
 
   objectSelector:
     # -- Allows selecting objects (pods) based on flexible matching rules for specific labels and fields.
-    matchExpressions: {}
+    matchExpressions: []
       # - key: foo
       #   operator: In
       #   values:
       #     - bar
     # -- In the MutatingWebhook, matchLabels selects objects (pods) based on specific labels matching exactly.
-    matchLabels: []
+    matchLabels: {}
       # foo: bar
 pki:
   certManager:


### PR DESCRIPTION
The default values were wrong, leading to an warning like:
```
coalesce.go:286: warning: cannot overwrite table with non table for amazon-eks-pod-identity-webhook.mutatingWebhook.objectSelector.matchExpressions (map[])
```