### PR TITLE
[keycloak-config-cli] feat: add nodeSelector, tolerations, affinity to Job pod

### DIFF
--- a/charts/keycloak-config-cli/Chart.yaml
+++ b/charts/keycloak-config-cli/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-config-cli
 description: Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 home: https://github.com/adorsys/keycloak-config-cli
-version: 1.3.7
+version: 1.3.8
 # renovate: docker=adorsys/keycloak-config-cli
 appVersion: 6.0.1
 maintainers:

--- a/charts/keycloak-config-cli/README.md
+++ b/charts/keycloak-config-cli/README.md
@@ -1,6 +1,6 @@
 # keycloak-config-cli
 
-![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![AppVersion: 6.0.1](https://img.shields.io/badge/AppVersion-6.0.1-informational?style=flat-square)
+![Version: 1.3.8](https://img.shields.io/badge/Version-1.3.8-informational?style=flat-square) ![AppVersion: 6.0.1](https://img.shields.io/badge/AppVersion-6.0.1-informational?style=flat-square)
 
 Import JSON-formatted configuration files into Keycloak - Configuration as Code for Keycloak.
 
@@ -15,7 +15,7 @@ helm install keycloak-config-cli jkroepke/keycloak-config-cli
 
 ## Maintainers
 
-| Name | Email | Url |
+| Name | Email | URL |
 | ---- | ------ | --- |
 | jkroepke | <github@jkroepke.de> | <https://github.com/jkroepke> |
 
@@ -27,6 +27,7 @@ helm install keycloak-config-cli jkroepke/keycloak-config-cli
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` |  |
 | annotations."helm.sh/hook" | string | `"post-install,post-upgrade,post-rollback"` |  |
 | annotations."helm.sh/hook-delete-policy" | string | `"hook-succeeded,before-hook-creation"` |  |
 | annotations."helm.sh/hook-weight" | string | `"5"` |  |
@@ -50,9 +51,11 @@ helm install keycloak-config-cli jkroepke/keycloak-config-cli
 | image.tag | string | `"{{ .Chart.AppVersion }}-17.0.1"` |  |
 | labels | object | `{}` |  |
 | nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
 | resources | object | `{}` |  |
 | secrets | object | `{}` |  |
 | securityContext | object | `{}` |  |
 | serviceAccount | string | `""` |  |
+| tolerations | list | `[]` |  |

--- a/charts/keycloak-config-cli/templates/job.yaml
+++ b/charts/keycloak-config-cli/templates/job.yaml
@@ -94,3 +94,15 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/keycloak-config-cli/values.yaml
+++ b/charts/keycloak-config-cli/values.yaml
@@ -87,3 +87,10 @@ extraVolumes: ""
 
 # Add additional volumes mounts, e. g. for custom secrets
 extraVolumeMounts: ""
+
+# Node scheduling for the Job pod
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### TL;DR

The Job pod spec accepts `securityContext`, `serviceAccount`, and various env/volume knobs, but no pod-scheduling fields. Adds `nodeSelector`, `tolerations`, `affinity`.

Fixes #149.

### Why

On clusters that use tainted spot pools, dedicated node pools, or topology-aware placement, the config-cli Job either lands wherever the scheduler picks or fails to schedule at all. Currently you can't nudge it without patching the chart.

### What

Three optional fields consumed exactly like the `securityContext` block above them:

- `nodeSelector` (default `{}`)
- `tolerations` (default `[]`)
- `affinity` (default `{}`)

Rendered on the Job pod spec via `{{- with .Values.X }}` blocks so they emit nothing when unset — same shape as `securityContext`, zero behavior change for existing users.

### Verified

`helm lint` clean. `helm template` with representative values for all three fields — everything renders at the right indentation on the Job pod spec.

DCO signed off.